### PR TITLE
ED-83: Date created is not being displayed correctly on tbdrugorder.csv

### DIFF
--- a/src/main/resources/sql/leafObs.sql
+++ b/src/main/resources/sql/leafObs.sql
@@ -3,8 +3,8 @@ select o.concept_id as conceptId,
   coalesce(DATE_FORMAT(o.value_datetime, '%d/%b/%Y'),o.value_numeric,o.value_text,cv.code,cvn.concept_full_name,cvn.concept_short_name) as value,
   ppa.value_reference as treatmentNumber,
   obs_con.concept_full_name as conceptName,
-  o.date_created as dateCreated,
-  GREATEST(COALESCE(o.date_created,0), COALESCE(ppa.date_changed,0)) as dateChanged
+  DATE_FORMAT(o.date_created,'%Y-%m-%d %H:%i:%S') as dateCreated,
+  DATE_FORMAT(GREATEST(COALESCE(o.date_created,0), COALESCE(ppa.date_changed,0)),'%Y-%m-%d %H:%i:%S')  as dateChanged
 from patient_program pp
 join program_attribute_type pg_at on (pg_at.name = 'Registration Number')
 left join  patient_program_attribute ppa  on (pp.patient_program_id = ppa.patient_program_id and pg_at.program_attribute_type_id=ppa.attribute_type_id)

--- a/src/main/resources/sql/nonTbDrugOrder.sql
+++ b/src/main/resources/sql/nonTbDrugOrder.sql
@@ -12,8 +12,8 @@ SELECT
   reason_admin.code as 'reas_othdrug',
   DATE_FORMAT(o.startDate, '%d/%b/%Y') as 'd_othdrugstart',
   DATE_FORMAT(o.stopDate, '%d/%b/%Y') as 'd_othdrugend',
-  MAX(o.date_created),
-  MAX(o.date_changed)
+  DATE_FORMAT(MAX(o.date_created),'%Y-%m-%d %H:%i:%S'),
+  DATE_FORMAT(MAX(o.date_changed),'%Y-%m-%d %H:%i:%S')
 FROM
   (SELECT
      IF(drug.name is NULL,drug_order.drug_non_coded, drug.name) as drugName,

--- a/src/main/resources/sql/tbDrugOrder.sql
+++ b/src/main/resources/sql/tbDrugOrder.sql
@@ -10,8 +10,8 @@ SELECT
   DATE_FORMAT(o.stopDate, '%d/%b/%Y')                                                        AS 'd_tbdrugend',
   o.stopped_order_reason                                                                     AS 'reas_tbd_stop',
   o.order_reason_non_coded                                                                   AS 'id_aenum_reas_d_stop_oth',
-  MAX(o.date_created),
-  MAX(o.date_changed)
+  DATE_FORMAT(MAX(o.date_created),'%Y-%m-%d %H:%i:%S'),
+  DATE_FORMAT(MAX(o.date_changed),'%Y-%m-%d %H:%i:%S')
 FROM
   (SELECT
      IF(drug.name IS NULL, drug_order.drug_non_coded, coalesce(drug_code.code, drug.name))                      AS drug,

--- a/src/main/resources/sql/treatmentRegistration.sql
+++ b/src/main/resources/sql/treatmentRegistration.sql
@@ -10,8 +10,8 @@ SELECT
   o.status,
   patient_id,
   patient_program_id,
-  MAX(o.date_created),
-  MAX(o.date_changed)
+  DATE_FORMAT(MAX(o.date_created),'%Y-%m-%d %H:%i:%S'),
+  DATE_FORMAT(MAX(o.date_changed),'%Y-%m-%d %H:%i:%S')
 FROM
   (SELECT
      CONCAT('\"',pi.identifier,'\"') as identifier,
@@ -28,14 +28,10 @@ FROM
      CONCAT('\"',outcome_concept.name, '\"') as status,
      pp.patient_program_id,
      pp.date_created as date_created,
-     GREATEST(COALESCE(pp.date_created,0),
-              COALESCE(pp.date_changed,0),
-              COALESCE(p.date_created,0),
-              COALESCE(p.date_changed,0),
-              COALESCE(pi.date_created,0),
-              COALESCE(pi.date_changed,0),
-              COALESCE(attr.date_created,0),
-              COALESCE(attr.date_changed,0)
+     GREATEST(COALESCE(pp.date_changed, pp.date_created),
+              COALESCE(p.date_changed, p.date_created),
+              COALESCE(pi.date_changed, pi.date_created),
+              COALESCE(attr.date_changed, attr.date_created)
      ) as date_changed
    FROM  patient_program pp
      JOIN program prog ON pp.program_id = prog.program_id AND pp.voided = 0


### PR DESCRIPTION
This is a fix for: https://tickets.pih-emr.org/browse/ED-83

When opening a CSV in Excel, if a datetime field contains a fraction of second component, Excel by default interprets the data as just a time, and displays only the time component.  Users have to manually change the type of the column in Excel.

It appears that if we use DATE_FORMAT to format dates to not include the fraction of a second component, the issue is resolved.

@davidoh  @SwathiVarkala let us know if you see any issues with this commit before we merge it in.  I've tested it locally, but will furthermore test it on our staging server after we merge it in. Thanks!